### PR TITLE
feat: add GDScript (Godot) Tier 2 language support

### DIFF
--- a/src/brain-scorer.ts
+++ b/src/brain-scorer.ts
@@ -36,7 +36,7 @@ interface SearchResult {
 
 const EXTENSION_WEIGHTS: Record<string, number> = {
     '.ts': 20, '.tsx': 20, '.js': 15, '.jsx': 15,
-    '.rs': 20, '.go': 20, '.py': 15,
+    '.rs': 20, '.go': 20, '.py': 15, '.gd': 15, '.tscn': 8,
     '.prisma': 15, '.graphql': 10,
     '.css': 5, '.json': 5, '.md': 2
 };

--- a/src/dependency-graph.ts
+++ b/src/dependency-graph.ts
@@ -451,7 +451,7 @@ export async function getQuickImportRanks(
     const codeFiles = files.filter(f =>
         f.endsWith('.ts') || f.endsWith('.tsx') ||
         f.endsWith('.js') || f.endsWith('.jsx') ||
-        f.endsWith('.py')
+        f.endsWith('.py') || f.endsWith('.gd')
     );
 
     // Limit to first 1000 files for speed

--- a/src/dependency-graph.ts
+++ b/src/dependency-graph.ts
@@ -168,8 +168,11 @@ export async function extractImports(filepath: string, cwd: string): Promise<Imp
 
             // GDScript imports
             if (filepath.endsWith('.gd')) {
+                const trimmedLine = line.trim();
+                if (trimmedLine.startsWith('#')) continue;
+
                 // extends "res://path/to/script.gd"
-                const extendsMatch = /^extends\s+["']([^"']+)["']/.exec(line.trim());
+                const extendsMatch = /^extends\s+["']([^"']+)["']/.exec(trimmedLine);
                 if (extendsMatch) {
                     imports.push({
                         source: normalizeGodotPath(extendsMatch[1]),
@@ -182,7 +185,7 @@ export async function extractImports(filepath: string, cwd: string): Promise<Imp
                 }
 
                 // preload("res://path") or load("res://path")
-                const loadMatch = /(preload|load)\s*\(\s*["']([^"']+)["']\s*\)/.exec(line);
+                const loadMatch = /(preload|load)\s*\(\s*["']([^"']+)["']\s*\)/.exec(trimmedLine);
                 if (loadMatch) {
                     imports.push({
                         source: normalizeGodotPath(loadMatch[2]),

--- a/src/dependency-graph.ts
+++ b/src/dependency-graph.ts
@@ -157,7 +157,51 @@ export async function extractImports(filepath: string, cwd: string): Promise<Imp
                 if (importMatch) {
                     imports.push({
                         source: importMatch[1],
-                        importedNames: [], // Import entire module
+                        importedNames: [],
+                        isDefault: true,
+                        isDynamic: false,
+                        line: lineNum + 1
+                    });
+                    continue;
+                }
+            }
+
+            // GDScript imports
+            if (filepath.endsWith('.gd')) {
+                // extends "res://path/to/script.gd"
+                const extendsMatch = /^extends\s+["']([^"']+)["']/.exec(line.trim());
+                if (extendsMatch) {
+                    imports.push({
+                        source: normalizeGodotPath(extendsMatch[1]),
+                        importedNames: [],
+                        isDefault: true,
+                        isDynamic: false,
+                        line: lineNum + 1
+                    });
+                    continue;
+                }
+
+                // preload("res://path") or load("res://path")
+                const loadMatch = /(preload|load)\s*\(\s*["']([^"']+)["']\s*\)/.exec(line);
+                if (loadMatch) {
+                    imports.push({
+                        source: normalizeGodotPath(loadMatch[2]),
+                        importedNames: [],
+                        isDefault: true,
+                        isDynamic: loadMatch[1] === 'load',
+                        line: lineNum + 1
+                    });
+                    continue;
+                }
+            }
+
+            // Godot scene (.tscn) ext_resource references
+            if (filepath.endsWith('.tscn')) {
+                const extResourceMatch = /\bpath\s*=\s*"([^"]+)"/.exec(line);
+                if (extResourceMatch) {
+                    imports.push({
+                        source: normalizeGodotPath(extResourceMatch[1]),
+                        importedNames: [],
                         isDefault: true,
                         isDynamic: false,
                         line: lineNum + 1
@@ -228,6 +272,14 @@ export async function extractExports(filepath: string, cwd: string): Promise<str
 }
 
 /**
+ * Convert a Godot res:// path to a plain project-relative path.
+ * "res://scripts/player.gd" → "scripts/player.gd"
+ */
+function normalizeGodotPath(source: string): string {
+    return source.startsWith('res://') ? source.slice('res://'.length) : source;
+}
+
+/**
  * Resolve import source to actual file path
  * Handles:
  * - Relative imports: ./Button, ../utils/auth
@@ -241,6 +293,16 @@ export function resolveImportPath(
     allFiles: string[],
     cwd: string
 ): string | null {
+    // Godot project-root-relative path (already normalized from res://)
+    // e.g. "scripts/player.gd" — resolve from cwd, not from importer
+    const isGodotAbsolute = !importSource.startsWith('.') &&
+                            !importSource.startsWith('@/') &&
+                            /\.(gd|tscn|tres)$/.test(importSource);
+    if (isGodotAbsolute) {
+        if (allFiles.includes(importSource)) return importSource;
+        return null;
+    }
+
     // External module (node_modules)
     if (!importSource.startsWith('.') && !importSource.startsWith('@/')) {
         return null;  // Ignore external dependencies
@@ -264,7 +326,7 @@ export function resolveImportPath(
     }
 
     // Try with common extensions
-    const extensions = ['.ts', '.tsx', '.js', '.jsx', '.mjs', ''];
+    const extensions = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.gd', '.tscn', ''];
     const indexFiles = ['/index.ts', '/index.tsx', '/index.js', '/index.jsx'];
 
     for (const ext of extensions) {

--- a/src/file-classifier.ts
+++ b/src/file-classifier.ts
@@ -45,6 +45,7 @@ const CONFIG_PATTERNS = [
     /docker-compose/,
     /\.gitignore$/,
     /\.editorconfig$/,
+    /\.tscn$/,
 ];
 
 // Test configuration patterns (should be classified as 'test', not 'config')
@@ -78,6 +79,7 @@ const CODE_EXTENSIONS = new Set([
     '.ts', '.tsx', '.js', '.jsx', '.mjs',
     '.py', '.java', '.go', '.rs', '.c', '.cpp',
     '.rb', '.php', '.swift', '.kt',
+    '.gd',
 ]);
 
 /**

--- a/src/project-classifier.ts
+++ b/src/project-classifier.ts
@@ -26,6 +26,11 @@ export function classifyProject(files: string[], techStack: string): ProjectMeta
              fileLower.some(f => f.endsWith('.vue'))) {
         projectType = 'vue';
     }
+    // Godot detection (before CLI — Godot addons often have bin/ directories)
+    else if (fileLower.some(f => f.includes('project.godot')) ||
+             fileLower.some(f => f.endsWith('.gd'))) {
+        projectType = 'godot';
+    }
     // CLI detection
     else if (fileLower.some(f => f.includes('bin/') || f.includes('cli.')) ||
              techStack.toLowerCase().includes('commander') ||
@@ -113,6 +118,7 @@ export function getProjectTypeDescription(metadata: ProjectMetadata): string {
         'python': 'Python project',
         'go': 'Go project',
         'rust': 'Rust project',
+        'godot': 'Godot project',
         'unknown': 'Unknown project type'
     };
 

--- a/src/repo-map.ts
+++ b/src/repo-map.ts
@@ -151,7 +151,7 @@ export async function generateRepoMap(cwd: string, options: MapOptions = {}): Pr
 
     // Filter to code files if requested
     if (codeOnly) {
-        const codeExtensions = new Set(['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs', '.java', '.rb', '.php']);
+        const codeExtensions = new Set(['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs', '.java', '.rb', '.php', '.gd']);
         files = files.filter(f => {
             const ext = path.extname(f).toLowerCase();
             return codeExtensions.has(ext);

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,6 +116,7 @@ export type ProjectType =
     | 'python'
     | 'go'
     | 'rust'
+    | 'godot'
     | 'unknown';
 
 export interface ProjectMetadata {


### PR DESCRIPTION
## Summary

- Adds `.gd` file support to file classification, repo map, and brain scorer relevance weighting
- Detects Godot projects via `project.godot` manifest or presence of `.gd` files (placed before CLI detection to avoid false positives from addon `bin/` directories)
- Tracks GDScript dependencies: `extends "res://..."`, `preload()`, and `load()` import patterns
- Adds `'godot'` to the `ProjectType` union with a human-readable description

## What's not included

No tree-sitter WASM is available for GDScript on jsDelivr, so go-to-definition and find-references are not supported. This puts GDScript at **Tier 2** — the same level as Go, Rust, Java, etc. — where all search, project detection, dependency tracking, and repo map features work correctly.

## Test plan

- [ ] Run `mantic map` in a Godot project — `Type:` should show `godot`
- [ ] Run `mantic search <query>` — `.gd` files should appear in results
- [ ] Verify `extends "res://..."`, `preload()`, `load()` are tracked in dependency graph (`--impact`)
- [ ] Confirm non-Godot projects are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-detect Godot projects and classify GDScript (.gd) and scene (.tscn) files as code/config.

* **Enhancements**
  * Extract and resolve Godot-specific dependencies (extends, preload/load, scene/resource paths).
  * Include .gd and .tscn in module resolution, quick-import scans, and code-only analyses.

* **Behavior Changes**
  * Apply extension-based scoring boosts for .gd and .tscn files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->